### PR TITLE
Update to include databricks-connect 9.1.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,11 @@ stages:
   jobs:  
   - template: .build/azure-pipelines-job-build.yml
     parameters:
+      DBCVER: 9.1.10
+      DBCVERNODOTS: 9110
+
+  - template: .build/azure-pipelines-job-build.yml
+    parameters:
       DBCVER: 8.1.10
       DBCVERNODOTS: 8110
 

--- a/environments/environment9.1.0.yml
+++ b/environments/environment9.1.0.yml
@@ -1,0 +1,9 @@
+name: dbconnect
+channels:
+  - conda-forge
+dependencies:
+  - python=3.8.12
+  - pip:
+    - databricks-connect==9.1.0
+    - six
+


### PR DESCRIPTION
Adds an environment.yml for databricks-connect 9.1.0 which was released last week
Also adds this to the release pipeline for docker

Please let me know if i've overlooked anything. I pushed python to 3.8.12 as it is the latest minor version which matches runtime 9.1