### PR TITLE
Update to initial DBR 11.3 LTS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,3 +27,8 @@ stages:
     parameters:
       DBCVER: 7.3.38
       DBCVERNODOTS: 7338
+
+  - template: .build/azure-pipelines-job-build.yml
+    parameters:
+      DBCVER: 11.3.0b0
+      DBCVERNODOTS: 1130b0

--- a/environments/environment11.3.0b0.yml
+++ b/environments/environment11.3.0b0.yml
@@ -1,0 +1,8 @@
+name: dbconnect
+channels:
+  - conda-forge
+dependencies:
+  - python=3.9.16
+  - pip:
+    - databricks-connect==11.3.0b0
+    - six


### PR DESCRIPTION
Databricks released an initial [Connect client for DBR 11.3 LTS](https://docs.databricks.com/release-notes/dbconnect/index.html#databricks-connect-1130b0). 

Next to 11.3 support I have updated Python to 3.9 as this is required for this new client.

This should be an easy update to this repository.